### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/Clean_data_log.py
+++ b/airflow/dags/Clean_data_log.py
@@ -2,24 +2,24 @@ from airflow import DAG
 from airflow.macros import *
 from airflow.operators.bash import BashOperator
 
-Dag_id = 'Clean_data_log'
+Dag_id = "Clean_data_log"
 dag = DAG(
     Dag_id,
-    schedule_interval='1 15 * * *',
+    schedule_interval="1 15 * * *",
     start_date=datetime(2023, 6, 25),
-    catchup=False
+    catchup=False,
 )
 
 clean_log = BashOperator(
     task_id="clean_log",
-    bash_command= r'find $AIRFLOW_HOME/logs/ -maxdepth 2 -name "run_id=*" -type d -mtime +0 -exec rm -rf {} +',
+    bash_command=r'find $AIRFLOW_HOME/logs/ -maxdepth 2 -name "run_id=*" -type d -mtime +0 -exec rm -rf {} +',
     dag=dag,
 )
 
 clean_data = BashOperator(
     task_id="clean_data",
-    bash_command= r'find $AIRFLOW_HOME/data/strayanimal_30days_data -type f -mtime +0 -exec rm -rf {} + && ' +
-                  r'find $AIRFLOW_HOME/data/strayanimal_today_data -type f -exec rm -rf {} +',
+    bash_command=r"find $AIRFLOW_HOME/data/strayanimal_30days_data -type f -mtime +0 -exec rm -rf {} + && "
+    + r"find $AIRFLOW_HOME/data/strayanimal_today_data -type f -exec rm -rf {} +",
     dag=dag,
 )
 


### PR DESCRIPTION
There appear to be some python formatting errors in 5a984bbb1077feb3c92a23b084a4d442399b8f95. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.