### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/dynamic_dags/plugin/chart_generator.py
+++ b/airflow/dags/dynamic_dags/plugin/chart_generator.py
@@ -4,16 +4,19 @@ import os
 
 file_dir = os.path.dirname(os.path.abspath(__file__))
 env = Environment(loader=FileSystemLoader(file_dir))
-template = env.get_template('chart_templated_dag.jinja2')
+template = env.get_template("chart_templated_dag.jinja2")
 
 
 with open(f"{file_dir}/config_chart.yml", "r") as cf:
     config = yaml.safe_load(cf)
 
-chart_dic_list = config['chart_data']
+chart_dic_list = config["chart_data"]
 minute = 30
 for i, chart_dic in enumerate(chart_dic_list):
-    chart_dic['schedule'] = f'{minute} 15 * * *'
-    with open(f"dags/dynamic_dags/Daily_Bigquery_to_Firestore_{chart_dic['chart_num']}.py", "w") as f:
+    chart_dic["schedule"] = f"{minute} 15 * * *"
+    with open(
+        f"dags/dynamic_dags/Daily_Bigquery_to_Firestore_{chart_dic['chart_num']}.py",
+        "w",
+    ) as f:
         f.write(template.render(chart_dic))
     minute += 1


### PR DESCRIPTION
There appear to be some python formatting errors in f26ad60b6729a30effef6c2c2e836fbd35576a60. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.