### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/Quarter_OpenAPI_today.py
+++ b/airflow/dags/Quarter_OpenAPI_today.py
@@ -80,8 +80,8 @@ def extract_data_OpenAPI(**context):
                 print(today_HM, "성공 데이터 :", result_df.shape[0])
                 break
         except Exception as e:
-            if e == 'item':
-                print(today_HM + '기준', '등록된 유기동물 데이터가 없습니다.')
+            if e == "item":
+                print(today_HM + "기준", "등록된 유기동물 데이터가 없습니다.")
                 break
             print(today_HM, "error :", e)
     else:


### PR DESCRIPTION
There appear to be some python formatting errors in 3612b0d0d342b4df860e4b840735a89e58a77335. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.