### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/Daily_Bigquery_Create_Analytics.py
+++ b/airflow/dags/Daily_Bigquery_Create_Analytics.py
@@ -1,5 +1,7 @@
 from airflow import DAG
-from airflow.providers.google.cloud.operators.bigquery import BigQueryExecuteQueryOperator
+from airflow.providers.google.cloud.operators.bigquery import (
+    BigQueryExecuteQueryOperator,
+)
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
 from datetime import datetime
@@ -70,8 +72,8 @@ with DAG(
     )
 
     trigger = TriggerDagRunOperator(
-        task_id='trigger',
-        trigger_dag_id='Daily_Bigquery_to_Firestore_chart_01',
+        task_id="trigger",
+        trigger_dag_id="Daily_Bigquery_to_Firestore_chart_01",
         wait_for_completion=False,
         poke_interval=30,
         allowed_states=["success"],

--- a/airflow/dags/dynamic_dags/plugin/chart_generator.py
+++ b/airflow/dags/dynamic_dags/plugin/chart_generator.py
@@ -4,18 +4,21 @@ import os
 
 file_dir = os.path.dirname(os.path.abspath(__file__))
 env = Environment(loader=FileSystemLoader(file_dir))
-template = env.get_template('chart_templated_dag.jinja2')
+template = env.get_template("chart_templated_dag.jinja2")
 
 
 with open(f"{file_dir}/config_chart.yml", "r") as cf:
     config = yaml.safe_load(cf)
 
-chart_dic_list = config['chart_data']
+chart_dic_list = config["chart_data"]
 
 for i, chart_dic in enumerate(chart_dic_list):
-    chart_dic['schedule'] = None
-    if i+1 != len(chart_dic_list):
-        chart_dic['call_trigger'] = '>> trigger' 
-        chart_dic['trigger_chart_num'] = chart_dic_list[i+1]['chart_num']
-    with open(f"dags/dynamic_dags/Daily_Bigquery_to_Firestore_{chart_dic['chart_num']}.py", "w") as f:
+    chart_dic["schedule"] = None
+    if i + 1 != len(chart_dic_list):
+        chart_dic["call_trigger"] = ">> trigger"
+        chart_dic["trigger_chart_num"] = chart_dic_list[i + 1]["chart_num"]
+    with open(
+        f"dags/dynamic_dags/Daily_Bigquery_to_Firestore_{chart_dic['chart_num']}.py",
+        "w",
+    ) as f:
         f.write(template.render(chart_dic))


### PR DESCRIPTION
There appear to be some python formatting errors in 4ac2622f34c83132509195d921fa7492f31fe7dc. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.