### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/Daily_Bigquery_Create_Analytics.py
+++ b/airflow/dags/Daily_Bigquery_Create_Analytics.py
@@ -1,5 +1,7 @@
 from airflow import DAG
-from airflow.providers.google.cloud.operators.bigquery import BigQueryExecuteQueryOperator
+from airflow.providers.google.cloud.operators.bigquery import (
+    BigQueryExecuteQueryOperator,
+)
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
 from datetime import datetime


### PR DESCRIPTION
There appear to be some python formatting errors in 6f74dfdbd132ade0309da10bf7fd15d875d3806c. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.