### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/Daily_Bigquery_Create_Analytics.py
+++ b/airflow/dags/Daily_Bigquery_Create_Analytics.py
@@ -11,7 +11,7 @@ default_args = {
     "depends_on_past": False,
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 1
+    "retries": 1,
 }
 
 excute_sql = """


### PR DESCRIPTION
There appear to be some python formatting errors in cd3723aa338e51585b7fd88dcd0b6ae46f55829e. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.