### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/Daily_OpenAPI_30days.py
+++ b/airflow/dags/Daily_OpenAPI_30days.py
@@ -165,7 +165,7 @@ def transform_data(**context):
     df["noticeSdt"] = pd.to_datetime(df["noticeSdt"], format="%Y%m%d")
     # print(df.info())
 
-    TRANSFORM_SAVE_NAME = "transform"+SAVE_NAME
+    TRANSFORM_SAVE_NAME = "transform" + SAVE_NAME
     TRANSFORM_LOCAL_PATH_NAME = os.path.join(
         os.environ["AIRFLOW_HOME"],
         "data",


### PR DESCRIPTION
There appear to be some python formatting errors in 9fe1de6467196325fbee8eecafa0e7629b5d51b7. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.