### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/plugins/slack.py
+++ b/airflow/dags/plugins/slack.py
@@ -3,24 +3,25 @@ from airflow.models import Variable
 import logging
 import requests
 
+
 def on_failure_callback(context):
     """
     https://airflow.apache.org/_modules/airflow/operators/slack_operator.html
     Define the callback to post on Slack if a failure is detected in the Workflow
     :return: operator.execute
     """
-    text = str(context['task_instance'])
-    text += "```" + str(context.get('exception')) +"```"
+    text = str(context["task_instance"])
+    text += "```" + str(context.get("exception")) + "```"
     send_message_to_a_slack_channel(text, ":scream:")
 
 
 # def send_message_to_a_slack_channel(message, emoji, channel, access_token):
 def send_message_to_a_slack_channel(message, emoji):
     # url = "https://slack.com/api/chat.postMessage"
-    url = "https://hooks.slack.com/services/"+Variable.get("slack_url")
+    url = "https://hooks.slack.com/services/" + Variable.get("slack_url")
     headers = {
-        'content-type': 'application/json',
+        "content-type": "application/json",
     }
-    data = { "username": "Data GOD", "text": message, "icon_emoji": emoji }
+    data = {"username": "Data GOD", "text": message, "icon_emoji": emoji}
     r = requests.post(url, json=data, headers=headers)
     return r


### PR DESCRIPTION
There appear to be some python formatting errors in f5327cb71481e27fee03a0f5f5fdb78ee7766555. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.