### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/plugins/slack.py
+++ b/airflow/dags/plugins/slack.py
@@ -5,7 +5,6 @@ import requests
 from datetime import datetime
 
 
-
 def on_failure_callback(context):
     """
     https://airflow.apache.org/_modules/airflow/operators/slack_operator.html


### PR DESCRIPTION
There appear to be some python formatting errors in 13fb3fee4d10e7528d4e636db0b7ab23510b0749. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.