### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/plugins/slack.py
+++ b/airflow/dags/plugins/slack.py
@@ -13,12 +13,7 @@ def on_failure_callback(context):
     """
     text = str(context["task_instance"])
     text += "```" + str(context.get("exception")) + "```"
-    text += (
-        "``` 발생시간 : "
-        + "```"
-        + datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        + "```"
-    )
+    text += "``` 발생시간 : " + "```" + datetime.now().strftime("%Y-%m-%d %H:%M:%S") + "```"
 
     send_message_to_a_slack_channel(text, ":scream:")
 


### PR DESCRIPTION
There appear to be some python formatting errors in 590e5c37acbaf052b636f980a6667505703f2ea2. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.