### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/cloud-function/create_data_firestore_function.py
+++ b/cloud-function/create_data_firestore_function.py
@@ -4,6 +4,7 @@ import datetime
 import sys
 import math
 
+
 def create_document_in(data, context):
     print(data, context)
     create_document()


### PR DESCRIPTION
There appear to be some python formatting errors in 3fbe615f0489c9e5b4233402c7fc7632f1172731. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.