### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/Daily_Bigquery_Create_Analytics.py
+++ b/airflow/dags/Daily_Bigquery_Create_Analytics.py
@@ -61,9 +61,11 @@ excute_sql = """
     LIMIT 10;
     """
 
+
 def on_failure():
-    print ("Daily_Bigquery_Create_Analytics 실패! {{ds}}")
+    print("Daily_Bigquery_Create_Analytics 실패! {{ds}}")
     raise AirflowException("bigquery execute query operator가 작업에 실패했습니다. {{ds}}")
+
 
 with DAG(
     dag_id="Daily_Bigquery_Create_Analytics",


### PR DESCRIPTION
There appear to be some python formatting errors in d8ae365c52fc7c89fc311037b278c9c01b2ef6a5. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.