### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/Daily_Bigquery_Create_Analytics.py
+++ b/airflow/dags/Daily_Bigquery_Create_Analytics.py
@@ -74,7 +74,7 @@ with DAG(
     max_active_runs=1,
     schedule_interval=None,
     default_args=default_args,
-    tags=['Bigquery', 'ELT']
+    tags=["Bigquery", "ELT"],
 ) as dag:
     bigquery_create_analytics_table = BigQueryExecuteQueryOperator(
         task_id="excute_query",


### PR DESCRIPTION
There appear to be some python formatting errors in 714164e75a832b2e12bc4dc3fb84d680efad17cd. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.