### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/Daily_Bigquery_Create_Analytics.py
+++ b/airflow/dags/Daily_Bigquery_Create_Analytics.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from airflow import DAG
 from airflow.exceptions import AirflowException
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
-from airflow.providers.google.cloud.operators.bigquery import BigQueryExecuteQueryOperator
+from airflow.providers.google.cloud.operators.bigquery import (
+    BigQueryExecuteQueryOperator,
+)
 
 from plugins import slack
 


### PR DESCRIPTION
There appear to be some python formatting errors in 943462cb563fea0834eaa4850a92ced6a86e2325. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.