### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/Daily_Bigquery_Create_Analytics.py
+++ b/airflow/dags/Daily_Bigquery_Create_Analytics.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from airflow import DAG
 from airflow.exceptions import AirflowException
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
-from airflow.providers.google.cloud.operators.bigquery import BigQueryExecuteQueryOperator
+from airflow.providers.google.cloud.operators.bigquery import (
+    BigQueryExecuteQueryOperator,
+)
 
 dasdasd
 from plugins import slack


### PR DESCRIPTION
There appear to be some python formatting errors in da237bb3a96480275f0e322eea98f0b0b081a5b1. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.