### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/Daily_Bigquery_Create_Analytics.py
+++ b/airflow/dags/Daily_Bigquery_Create_Analytics.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from airflow import DAG
 from airflow.exceptions import AirflowException
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
-from airflow.providers.google.cloud.operators.bigquery import BigQueryExecuteQueryOperator
+from airflow.providers.google.cloud.operators.bigquery import (
+    BigQueryExecuteQueryOperator,
+)
 
 asdadssa
 


### PR DESCRIPTION
There appear to be some python formatting errors in 5e035e5516a8408a13f18b360bb6b29067af3bcb. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.