### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/airflow/dags/Daily_Bigquery_Create_Analytics.py
+++ b/airflow/dags/Daily_Bigquery_Create_Analytics.py
@@ -8,7 +8,6 @@ from airflow.providers.google.cloud.operators.bigquery import (
 )
 
 
-
 from plugins import slack
 
 default_args = {


### PR DESCRIPTION
There appear to be some python formatting errors in 85fd97ee9aadeacea511d36bbf7d9f8ffc4cbc3e. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.